### PR TITLE
Document analytics query parameters

### DIFF
--- a/docs/TDD.md
+++ b/docs/TDD.md
@@ -431,7 +431,14 @@ class CreateTradeRequest(BaseModel):
 
 ### 3.4 Analytics
 ```python
+# Query parameters shared by all analytics endpoints
+class AnalyticsQueryParams(BaseModel):
+    start_date: Optional[date]
+    end_date: Optional[date]
+    tag_id: Optional[UUID]
+
 # GET /api/analytics/summary
+# Example: GET /api/analytics/summary?start_date=2024-01-01&end_date=2024-03-31&tag_id=<UUID>
 class AnalyticsSummary(BaseModel):
     total_trades: int
     win_rate: float
@@ -441,6 +448,7 @@ class AnalyticsSummary(BaseModel):
     average_holding_time: timedelta
 
 # GET /api/analytics/time-based
+# Example: GET /api/analytics/time-based?start_date=2024-01-01&end_date=2024-03-31&tag_id=<UUID>
 class TimeBasedAnalytics(BaseModel):
     daily: List[DailyAnalytics]
     monthly: List[MonthlyAnalytics]
@@ -468,6 +476,7 @@ class DayOfWeekAnalytics(BaseModel):
     trades: int
 
 # GET /api/analytics/tags
+# Example: GET /api/analytics/tags?start_date=2024-01-01&end_date=2024-03-31
 class TagAnalytics(BaseModel):
     tag_id: UUID
     tag_name: str
@@ -476,6 +485,7 @@ class TagAnalytics(BaseModel):
     total_pnl: Decimal
 
 # GET /api/analytics/export
+# Example: GET /api/analytics/export?start_date=2024-01-01&end_date=2024-03-31&tag_id=<UUID>
 # Returns CSV or JSON based on Accept header
 ```
 


### PR DESCRIPTION
## Summary
- add `AnalyticsQueryParams` model for analytics request filters
- show example queries for analytics endpoints

## Testing
- `pip install -r backend/requirements.txt`
- `PYTHONPATH=$(pwd) pytest backend/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_6843c19ee7fc83298d15e6bf8be5dbe5