### PR TITLE
Scaffold backend API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+app.db
+__pycache__/
+backend/**/__pycache__/
+*.pyc
+

--- a/backend/app/api/analytics.py
+++ b/backend/app/api/analytics.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.get("/summary")
+def analytics_summary():
+    return {"total_trades": 0, "win_rate": 0.0}
+
+@router.get("/time-based")
+def analytics_time_based():
+    return {"daily": [], "monthly": []}
+
+@router.get("/tags")
+def analytics_tags():
+    return {"tags": []}
+
+@router.get("/export")
+def analytics_export():
+    return {"exported_at": datetime.utcnow().isoformat()}

--- a/backend/app/api/brokerage.py
+++ b/backend/app/api/brokerage.py
@@ -1,0 +1,28 @@
+from datetime import datetime
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.get("/accounts")
+def list_accounts():
+    return {"accounts": []}
+
+@router.post("/connect")
+def connect_brokerage():
+    return {"auth_url": "https://example.com/auth", "state": "dummy"}
+
+@router.get("/callback")
+def oauth_callback():
+    return {"status": "ok"}
+
+@router.post("/disconnect")
+def disconnect_brokerage():
+    return {"status": "disconnected"}
+
+@router.post("/sync")
+def sync_brokerage():
+    return {"trades_synced": 0, "last_sync_date": datetime.utcnow()}
+
+@router.get("/positions")
+def list_positions():
+    return {"positions": []}

--- a/backend/app/api/journal_entries.py
+++ b/backend/app/api/journal_entries.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+from uuid import uuid4
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.get("/")
+def list_entries():
+    return {"entries": []}
+
+@router.post("/")
+def create_entry():
+    return {"id": str(uuid4()), "created_at": datetime.utcnow()}
+
+@router.put("/{entry_id}")
+def update_entry(entry_id: str):
+    return {"id": entry_id, "updated": True}
+
+@router.delete("/{entry_id}")
+def delete_entry(entry_id: str):
+    return {"id": entry_id, "deleted": True}
+
+@router.get("/calendar")
+def journal_calendar():
+    return {"entries": []}
+
+@router.get("/search")
+def journal_search():
+    return {"results": []}

--- a/backend/app/api/profile.py
+++ b/backend/app/api/profile.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+from fastapi import APIRouter
+
+router = APIRouter()
+
+FAKE_PROFILE = {
+    "id": "00000000-0000-0000-0000-000000000000",
+    "created_at": datetime.utcnow(),
+    "updated_at": datetime.utcnow(),
+    "display_name": "Trader",
+    "timezone": "UTC",
+}
+
+@router.get("/")
+def get_profile():
+    return FAKE_PROFILE
+
+@router.put("/")
+def update_profile(display_name: str | None = None, timezone: str | None = None):
+    if display_name is not None:
+        FAKE_PROFILE["display_name"] = display_name
+    if timezone is not None:
+        FAKE_PROFILE["timezone"] = timezone
+    FAKE_PROFILE["updated_at"] = datetime.utcnow()
+    return FAKE_PROFILE

--- a/backend/app/api/tags.py
+++ b/backend/app/api/tags.py
@@ -1,0 +1,29 @@
+from uuid import uuid4
+from fastapi import APIRouter
+
+router = APIRouter()
+
+tags_store = {}
+
+@router.get("/")
+def list_tags():
+    return {"tags": list(tags_store.values())}
+
+@router.post("/")
+def create_tag(name: str):
+    tag_id = str(uuid4())
+    tag = {"id": tag_id, "name": name}
+    tags_store[tag_id] = tag
+    return tag
+
+@router.put("/{tag_id}")
+def update_tag(tag_id: str, name: str):
+    tag = tags_store.get(tag_id, {"id": tag_id})
+    tag["name"] = name
+    tags_store[tag_id] = tag
+    return tag
+
+@router.delete("/{tag_id}")
+def delete_tag(tag_id: str):
+    tags_store.pop(tag_id, None)
+    return {"id": tag_id, "deleted": True}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,10 +1,23 @@
 from fastapi import FastAPI
-from .api import trades, tastytrade
+from .api import (
+    trades,
+    tastytrade,
+    brokerage,
+    analytics,
+    journal_entries,
+    tags as tags_api,
+    profile,
+)
 
 app = FastAPI(title="Trade Blotter API")
 
 app.include_router(trades.router, prefix="/api/trades", tags=["trades"])
 app.include_router(tastytrade.router, prefix="/api/tastytrade", tags=["tastytrade"])
+app.include_router(brokerage.router, prefix="/api/brokerage", tags=["brokerage"])
+app.include_router(analytics.router, prefix="/api/analytics", tags=["analytics"])
+app.include_router(journal_entries.router, prefix="/api/journal-entries", tags=["journal-entries"])
+app.include_router(tags_api.router, prefix="/api/tags", tags=["tags"])
+app.include_router(profile.router, prefix="/api/profile", tags=["profile"])
 
 @app.get("/health")
 def health_check():

--- a/backend/tests/test_api_scaffold.py
+++ b/backend/tests/test_api_scaffold.py
@@ -1,0 +1,14 @@
+from fastapi.testclient import TestClient
+from backend.app.main import app
+
+client = TestClient(app)
+
+def test_profile_endpoint():
+    resp = client.get("/api/profile/")
+    assert resp.status_code == 200
+    assert "id" in resp.json()
+
+def test_brokerage_sync_endpoint():
+    resp = client.post("/api/brokerage/sync")
+    assert resp.status_code == 200
+    assert resp.json().get("trades_synced") == 0


### PR DESCRIPTION
## Summary
- add FastAPI route placeholders for brokerage, analytics, journal entries, tags and profile
- register new routers in `main.py`
- add basic API tests
- ignore database and cache files

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843c97bda5483299b56d58c9a136cbc